### PR TITLE
feat: allow configuration of manage groups link

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -11,14 +11,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          # Use fetch-depth:0 to fetch all history for all tags to make Spotless Ratcheting work.
+          fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
+        uses: gradle/gradle-build-action@v3
         with:
           arguments: clean build test
       - name: Docker build

--- a/VERSION
+++ b/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-VERSION="1.3.0"
+VERSION="1.4.0"
 TAGS="${VERSION} ${VERSION}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VERSION

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,8 @@ repositories {
     mavenLocal()
 }
 
+sourceCompatibility = '11'
+
 dependencies {
     implementation 'com.opencsv:opencsv:[5.9,6.0)'
     implementation 'org.freemarker:freemarker:[2.3.31,2.4.0)'
@@ -46,8 +48,6 @@ dependencies {
     testImplementation 'org.seleniumhq.selenium:selenium-java:[3.14,4.0)'
 }
 
-sourceCompatibility = 11
-
 spotless {
     // optional: only format files which have changed since origin/main
     ratchetFrom 'origin/main'
@@ -77,20 +77,20 @@ check.dependsOn spotlessCheck
 // Create Java Code Coverage Reports
 jacocoTestReport {
     reports {
-        xml.enabled true
-        html.enabled true
+        xml.required = true
+        html.required = true
     }
 }
 check.dependsOn jacocoTestReport
 
 // Create JavaDoc
 javadoc {
-    destinationDir = file("${buildDir}/docs/javadoc")
+    destinationDir = file("${layout.buildDirectory}/docs/javadoc")
 }
 
 // Create Java Documentation using Dokka for Github Markdown and HTML
 tasks.dokkaGfm.configure {
-    outputDirectory.set(file("${buildDir}/docs/dokka/gfm"))
+    outputDirectory.set(file("${layout.buildDirectory}/docs/dokka/gfm"))
     dokkaSourceSets {
         register("main") {
             sourceRoots.from(file("src/main/java"))
@@ -99,7 +99,7 @@ tasks.dokkaGfm.configure {
 }
 
 tasks.dokkaHtml.configure {
-    outputDirectory.set(file("${buildDir}/docs/dokka/html"))
+    outputDirectory.set(file("${layout.buildDirectory}/docs/dokka/html"))
     dokkaSourceSets {
         register("main") {
             sourceRoots.from(file("src/main/java"))
@@ -116,7 +116,7 @@ tasks.dokkaHtml.configure {
 
 
 war {
-    archiveName 'storage.war'
+    archiveFileName = 'storage.war'
 }
 
 ext {
@@ -136,17 +136,17 @@ configurations {
 
 idea {
     module {
-        //and some extra test source dirs
+        // add integration test dir
         testSourceDirs += file('src/intTest/java')
     }
 }
 
 ['firefox', 'chrome'].each { driver ->
-    task "intTest${driver.capitalize()}"(type: Test) { driverTest ->
+    tasks.register("intTest${driver.capitalize()}", Test) { driverTest ->
         testClassesDirs = sourceSets.intTest.output.classesDirs
         classpath = sourceSets.intTest.runtimeClasspath
         reports {
-            html.destination = reporting.file("$name/html")
+            html.outputLocation = reporting.file("$name/html")
         }
         dependencies {
             intTestImplementation 'junit:junit:[4.12,5.0)'
@@ -180,6 +180,12 @@ idea {
             System.err.println("Please set the intTest_user_name property (-PintTest_user_name=cadcuser).")
         } else {
             systemProperty 'user.name', project.intTest_user_name
+        }
+
+        if (!project.hasProperty('intTest_home_root')) {
+            System.err.println("Using default home.root (-PintTest_home_root=/ for vault, or -PintTest_home_root=/home for cavern).  Default is / (vault).")
+        } else {
+            systemProperty 'home.root', project.intTest_home_root
         }
 
         if (!project.hasProperty('intTest_user_password')) {

--- a/src/main/java/net/canfar/storage/web/config/VOSpaceServiceConfig.java
+++ b/src/main/java/net/canfar/storage/web/config/VOSpaceServiceConfig.java
@@ -82,10 +82,18 @@ public class VOSpaceServiceConfig {
 
     private final Features features;
 
+    // The link to the group management service.  Set as a URI in case it will be looked up as a Registry entry instead.
+    private final URI groupManagementLinkURI;
+
     // Default provided, can be overridden
     public String homeDir;
 
-    public VOSpaceServiceConfig(String name, URI resourceID, URI nodeResourceID, final Features features) {
+    public VOSpaceServiceConfig(
+            String name,
+            URI resourceID,
+            URI nodeResourceID,
+            final Features features,
+            final URI groupManagementLinkURI) {
 
         // Validation for required properties
         if (!StringUtil.hasLength(name)) {
@@ -105,6 +113,8 @@ public class VOSpaceServiceConfig {
 
         // Set default for optional properties
         this.homeDir = "/";
+
+        this.groupManagementLinkURI = groupManagementLinkURI;
     }
 
     public String getName() {
@@ -117,6 +127,10 @@ public class VOSpaceServiceConfig {
 
     public URI getNodeResourceID() {
         return this.nodeResourceID;
+    }
+
+    public URI getGroupManagementLinkURI() {
+        return this.groupManagementLinkURI;
     }
 
     public boolean supportsBatchDownloads() {

--- a/src/main/java/net/canfar/storage/web/config/VOSpaceServiceConfigManager.java
+++ b/src/main/java/net/canfar/storage/web/config/VOSpaceServiceConfigManager.java
@@ -86,6 +86,7 @@ public class VOSpaceServiceConfigManager {
     public static final String SERVICE_NAME_RESOURCE_ID_PROPERTY_KEY_FORMAT = "%s%s.service.resourceid";
     public static final String SERVICE_NODE_RESOURCE_ID_PROPERTY_KEY_FORMAT = "%s%s.node.resourceid";
     public static final String SERVICE_USER_HOME_PROPERTY_KEY_FORMAT = "%s%s.user.home";
+    public static final String SERVICE_GROUP_MANAGEMENT_URI_KEY_FORMAT = "%s%s.service.groupManagementURI";
     public static final String SERVICE_FEATURE_BATCH_UPLOAD_PROPERTY_KEY_FORMAT = "%s%s.service.features.batchUpload";
     public static final String SERVICE_FEATURE_BATCH_DOWNLOAD_PROPERTY_KEY_FORMAT =
             "%s%s.service.features.batchDownload";
@@ -144,9 +145,21 @@ public class VOSpaceServiceConfigManager {
                     storageServiceName);
             final String userHomeStr = applicationConfiguration.lookup(userHomePrefixKey, true);
 
+            final String groupManagementURIPrefixKey = String.format(
+                    VOSpaceServiceConfigManager.SERVICE_GROUP_MANAGEMENT_URI_KEY_FORMAT,
+                    VOSpaceServiceConfigManager.KEY_BASE,
+                    storageServiceName);
+            final String groupManagementURIPrefixKeyStr =
+                    applicationConfiguration.lookup(groupManagementURIPrefixKey, true);
+
             // At this point, the values have been validated
             final VOSpaceServiceConfig voSpaceServiceConfig = new VOSpaceServiceConfig(
-                    storageServiceName, vospaceResourceID, nodeResourceID, getFeatures(storageServiceName));
+                    storageServiceName,
+                    vospaceResourceID,
+                    nodeResourceID,
+                    getFeatures(storageServiceName),
+                    URI.create(groupManagementURIPrefixKeyStr));
+
             voSpaceServiceConfig.homeDir = userHomeStr;
 
             this.serviceConfigMap.put(storageServiceName, voSpaceServiceConfig);

--- a/src/main/java/net/canfar/storage/web/resources/MainPageServerResource.java
+++ b/src/main/java/net/canfar/storage/web/resources/MainPageServerResource.java
@@ -210,6 +210,9 @@ public class MainPageServerResource extends StorageItemServerResource {
         // Used to populate VOSpace service dropdown
         dataModel.put("vospaceServices", getVOSpaceServiceList());
 
+        // Group Manager link
+        dataModel.put("groupManagerLinkURI", this.currentService.getGroupManagementLinkURI());
+
         final String httpUsername = getDisplayName();
 
         if (httpUsername != null) {

--- a/src/main/java/net/canfar/storage/web/restlet/VOSpaceStatusService.java
+++ b/src/main/java/net/canfar/storage/web/restlet/VOSpaceStatusService.java
@@ -68,17 +68,19 @@
 
 package net.canfar.storage.web.restlet;
 
-
 import ca.nrc.cadc.auth.NotAuthenticatedException;
 import ca.nrc.cadc.net.ResourceAlreadyExistsException;
 import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.util.StringUtil;
+import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import net.canfar.storage.web.config.StorageConfiguration;
 import net.canfar.storage.web.config.VOSpaceServiceConfig;
 import net.canfar.storage.web.config.VOSpaceServiceConfigManager;
-import org.opencadc.vospace.*;
-import net.canfar.storage.web.config.StorageConfiguration;
 import net.canfar.storage.web.view.FreeMarkerConfiguration;
-
+import org.opencadc.vospace.*;
 import org.restlet.Context;
 import org.restlet.Request;
 import org.restlet.Response;
@@ -91,23 +93,13 @@ import org.restlet.representation.StringRepresentation;
 import org.restlet.resource.ResourceException;
 import org.restlet.service.StatusService;
 
-import java.io.FileNotFoundException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
-
-/**
- * Translate Exceptions into HTTP Statuses.
- */
+/** Translate Exceptions into HTTP Statuses. */
 public class VOSpaceStatusService extends StatusService {
     private final StorageConfiguration storageConfiguration = new StorageConfiguration();
     private final VOSpaceServiceConfigManager voSpaceServiceConfigManager =
             new VOSpaceServiceConfigManager(storageConfiguration);
-    private final static int[] PLAIN_TEXT_STATUS_CODES = new int[] {
-            Status.CLIENT_ERROR_BAD_REQUEST.getCode(),
-            Status.CLIENT_ERROR_PRECONDITION_FAILED.getCode()
-    };
+    private static final int[] PLAIN_TEXT_STATUS_CODES =
+            new int[] {Status.CLIENT_ERROR_BAD_REQUEST.getCode(), Status.CLIENT_ERROR_PRECONDITION_FAILED.getCode()};
 
     @Override
     public Representation toRepresentation(final Status status, final Request request, final Response response) {
@@ -130,10 +122,14 @@ public class VOSpaceStatusService extends StatusService {
             dataModel.put("requestedFolder", requestedResource);
             dataModel.put("vospaceSvcPath", currentService.getName() + "/");
 
-            return new TemplateRepresentation(String.format("themes/%s/error.ftl", storageConfiguration.getThemeName()),
-                                              (FreeMarkerConfiguration) curContext.getAttributes()
-                                                                                  .get(StorageApplication.FREEMARKER_CONFIG_KEY),
-                                              dataModel, MediaType.TEXT_HTML);
+            // Group Manager link
+            dataModel.put("groupManagerLink", currentService.getGroupManagementLinkURI());
+
+            return new TemplateRepresentation(
+                    String.format("themes/%s/error.ftl", storageConfiguration.getThemeName()),
+                    (FreeMarkerConfiguration) curContext.getAttributes().get(StorageApplication.FREEMARKER_CONFIG_KEY),
+                    dataModel,
+                    MediaType.TEXT_HTML);
         }
     }
 
@@ -164,8 +160,8 @@ public class VOSpaceStatusService extends StatusService {
      * Returns a status for a given exception or error.
      *
      * @param throwable The exception or error caught.
-     * @param request   The request handled.
-     * @param response  The response updated.
+     * @param request The request handled.
+     * @param response The response updated.
      * @return The representation of the given status.
      */
     @Override
@@ -176,8 +172,8 @@ public class VOSpaceStatusService extends StatusService {
             status = toStatus(throwable.getCause(), request, response);
         } else if (throwable instanceof ResourceException) {
             final Throwable cause = throwable.getCause();
-            status = (cause == null)
-                     ? super.toStatus(throwable, request, response) : toStatus(cause, request, response);
+            status =
+                    (cause == null) ? super.toStatus(throwable, request, response) : toStatus(cause, request, response);
         } else if (throwable instanceof IllegalArgumentException) {
             // Prune out any CR or LF that might come from web services, or they'll
             // get converted to a helpful message about how they need to be removed
@@ -190,8 +186,9 @@ public class VOSpaceStatusService extends StatusService {
                 statusCode = Status.CLIENT_ERROR_BAD_REQUEST.getCode();
             }
             status = new Status(statusCode, thrownMessage, thrownMessage);
-        } else if ((throwable instanceof FileNotFoundException) || (throwable instanceof NodeNotFoundException)
-                   || (throwable instanceof ResourceNotFoundException)) {
+        } else if ((throwable instanceof FileNotFoundException)
+                || (throwable instanceof NodeNotFoundException)
+                || (throwable instanceof ResourceNotFoundException)) {
             status = Status.CLIENT_ERROR_NOT_FOUND;
         } else if (throwable instanceof NotAuthenticatedException) {
             status = Status.CLIENT_ERROR_UNAUTHORIZED;
@@ -204,12 +201,12 @@ public class VOSpaceStatusService extends StatusService {
             final String message = throwable.getMessage();
 
             status = (message.contains("(409)"))
-                     ? Status.CLIENT_ERROR_CONFLICT : super.toStatus(throwable, request, response);
+                    ? Status.CLIENT_ERROR_CONFLICT
+                    : super.toStatus(throwable, request, response);
         } else {
             status = super.toStatus(throwable, request, response);
         }
 
         return status;
     }
-
 }

--- a/src/main/webapp/js/filemanager.js
+++ b/src/main/webapp/js/filemanager.js
@@ -1,8 +1,8 @@
-'use strict'
+ 'use strict'
 /**
- *  Filemanager JS core
+ *  File Manager JS core
  *
- *  filemanager.jsl
+ *  filemanager.js
  *
  *  @license  MIT License
  *  @author    Jason Huck - Core Five Labs
@@ -22,7 +22,7 @@ function fileManager(
   useDefaultLogin,
   vospaceServicePath,
   vosNodePrefixURI,
-  features
+  groupManagerLinkURI
 ) {
   // function to retrieve GET params
   $.urlParam = function(name) {
@@ -1526,7 +1526,7 @@ function fileManager(
 
   $(document).on('click', '.glyphicon-pencil', function(event) {
     // Pull attributes from edit icon
-    var $iconAnchor = $(event.currentTarget).find('a')
+    const $iconAnchor = $(event.currentTarget).find('a')
 
     // Flag this icon as the currently active one
     // will be referenced for seeing if form values have changed
@@ -1556,79 +1556,61 @@ function fileManager(
     }
   })
 
-  var loadEditPermPrompt = function(promptData) {
-    var checkboxState = ''
-    if (promptData.data('readable') === true) {
-      checkboxState = 'checked'
-    }
-    var msg =
-      '<div class="form-group fm-prompt">' +
-      '<label for="publicPermission" class="control-label col-sm-4">' +
-      lg.public_question +
-      '</label>' +
-      '<div class="col-sm-7">' +
-      '<input style="margin: 9px 0 0;" class="action-hook" type="checkbox" id="publicPermission" name="publicPermission" ' +
-      checkboxState +
-      '>' +
-      '</div>' +
-      '</div>' +
-      '<div class="form-group ui-front fm-prompt" id="readGroupDiv"> ' +
-      '<label for="readGroup" id="readGroupLabel" class="control-label col-sm-4">' +
-      lg.READ_GROUP +
-      '</label>' +
-      '<div id="readGroupInputDiv" class="col-sm-7"> ' +
-      '<input type="text" class="form-control  ui-autocomplete-input action-hook" id="readGroup" name="readGroup" placeholder="' +
-      lg.group_name_program_id +
-      '">' +
-      '</div>' +
-      '</div>' +
-      '<div class="form-group ui-front fm-prompt" id="writeGroupDiv">' +
-      '<label for="writeGroup" id="writeGroupLabel" class="control-label col-sm-4">' +
-      lg.WRITE_GROUP +
-      '</label>' +
-      '<div class="col-sm-7">' +
-      '<input type="text" class="form-control action-hook" id="writeGroup" name="writeGroup" placeholder="' +
-      lg.group_name_program_id +
-      '">' +
-      '</div>' +
-      '</div>' +
-      '<div class="form-group fm-prompt">' +
-      '<label for="recursive" class="control-label col-sm-4"">' +
-      lg.recursive +
-      '</label>' +
-      '<div class="col-sm-7">' +
-      '<input style="margin: 9px 0 0;" class="action-hook" type="checkbox" id="recursive" name="recursive">' +
-      '</div>' +
-      '</div>' +
-      '<div class="form-group fm-prompt">' +
-      '<div class="col-sm-4" >' +
-      '</div>' +
-      '<div class="col-sm-7 prompt-link">' +
-      '<a href="https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/en/groups/" target="_blank">Manage Groups</a>' +
-      '<input type="text" class="hidden" name="itemPath" id="itemPath" value="' +
-      promptData.data('path') +
-      '">' +
-      '</div>' +
-      '</div>'
+  var loadEditPermPrompt = (promptData) => {
+    const checkboxState = promptData.data('readable') === true ? 'checked' : ''
 
-    var btns = []
-    btns.push({
-      name: 'b1',
-      title: lg.save,
-      value: true,
-      classes: 'btn btn-primary listener-hook'
-    })
-    btns.push({
-      name: 'b2',
-      title: lg.cancel,
-      value: false,
-      classes: 'btn btn-default'
-    })
+    const msg =
+      `<div class="form-group fm-prompt">
+       <label for="publicPermission" class="control-label col-sm-4">${lg.public_question}</label>
+       <div class="col-sm-7">
+       <input style="margin: 9px 0 0;" class="action-hook" type="checkbox" id="publicPermission" name="publicPermission" ${checkboxState}>
+       </div>
+       </div>
+       <div class="form-group ui-front fm-prompt" id="readGroupDiv">
+       <label for="readGroup" id="readGroupLabel" class="control-label col-sm-4">${lg.READ_GROUP}</label>
+       <div id="readGroupInputDiv" class="col-sm-7">
+       <input type="text" class="form-control  ui-autocomplete-input action-hook" id="readGroup" name="readGroup" placeholder="${lg.group_name_program_id}">
+       </div>
+       </div>
+       <div class="form-group ui-front fm-prompt" id="writeGroupDiv">
+       <label for="writeGroup" id="writeGroupLabel" class="control-label col-sm-4">${lg.WRITE_GROUP}</label>
+       <div class="col-sm-7">
+       <input type="text" class="form-control action-hook" id="writeGroup" name="writeGroup" placeholder="${lg.group_name_program_id}">
+       </div>
+       </div>
+       <div class="form-group fm-prompt">
+       <label for="recursive" class="control-label col-sm-4"">${lg.recursive}</label>
+       <div class="col-sm-7">
+       <input style="margin: 9px 0 0;" class="action-hook" type="checkbox" id="recursive" name="recursive">
+       </div>
+       </div>
+       <div class="form-group fm-prompt">
+       <div class="col-sm-4"></div>
+       <div class="col-sm-7 prompt-link">
+       <a href="${groupManagerLinkURI}" target="_blank">Manage Groups</a>
+       <input type="text" class="hidden" name="itemPath" id="itemPath" value="${promptData.data('path')}">
+       </div>
+       </div>`
+
+    const btns = [
+      {
+        name: 'b1',
+        title: lg.save,
+        value: true,
+        classes: 'btn btn-primary listener-hook'
+      },
+      {
+        name: 'b2',
+        title: lg.cancel,
+        value: false,
+        classes: 'btn btn-default'
+      }
+    ]
 
     // 'classes' entry below is to enable bootstrap to
     // handle styling, including form-horizontal
 
-    var states = {
+    const states = {
       state0: {
         title: '<h3 class="prompt-h3">' + promptData.data('itemname') + '</h3>',
         html: msg,
@@ -1666,10 +1648,10 @@ function fileManager(
         // Set initial form state
         $('#readGroup').val(promptData.data('readgroup'))
         $('#writeGroup').val(promptData.data('writegroup'))
-        var listenerHook = $('.listener-hook')
+        const listenerHook = $('.listener-hook')
         listenerHook.addClass('disabled')
 
-        $('.action-hook').on('click', function(event) {
+        $('.action-hook').on('click', () => {
           listenerHook.removeClass('disabled')
         })
       }

--- a/src/main/webapp/themes/canfar/index.ftl
+++ b/src/main/webapp/themes/canfar/index.ftl
@@ -149,7 +149,7 @@ jenkinsd 2017.04.04
                                   // a moving barber pole progress.
                                   fileManager(rows, $("#beacon"), "<#if startURI??>${startURI}</#if>", "${folder.path}",
                                               ${folderWritable?c}, 100 , json, "${contextPath}", false,
-                                              "${vospaceSvcPath}", "${vospaceNodePrefixURI}");
+                                              "${vospaceSvcPath}", "${vospaceNodePrefixURI}", "${groupManagerLinkURI}");
                                 })
                           .fail(function (request, textStatus, errorThrown)
                                 {

--- a/src/main/webapp/themes/default/index.ftl
+++ b/src/main/webapp/themes/default/index.ftl
@@ -120,7 +120,7 @@
                                   // Initial row count is 100 by default to just show a moving barber pole progress.
                                   fileManager(rows, $("#beacon"), "<#if startURI??>${startURI}</#if>", "${folder.path}",
                                               ${folderWritable?c}, 100 , json, "${contextPath}", true,
-                                              "${vospaceSvcPath}", "${vospaceNodePrefixURI}");
+                                              "${vospaceSvcPath}", "${vospaceNodePrefixURI}", "${groupManagerLinkURI}");
                                 })
                           .fail(function (request, textStatus, errorThrown)
                                 {

--- a/src/main/webapp/themes/src/index.ftl
+++ b/src/main/webapp/themes/src/index.ftl
@@ -121,7 +121,7 @@
 
                           fileManager(rows, $("#beacon"), "<#if startURI??>${startURI}</#if>", "${folder.path}",
                                       ${folderWritable?c}, 100, json, "${contextPath}", true,
-                                      "${vospaceSvcPath}", "${vospaceNodePrefixURI}", {})
+                                      "${vospaceSvcPath}", "${vospaceNodePrefixURI}", "${groupManagerLinkURI}")
                         } catch (error) {
                           console.error(error)
                         }

--- a/src/test/java/net/canfar/storage/web/StorageItemFactoryTest.java
+++ b/src/test/java/net/canfar/storage/web/StorageItemFactoryTest.java
@@ -1,4 +1,3 @@
-
 /*
  ************************************************************************
  *******************  CANADIAN ASTRONOMY DATA CENTRE  *******************
@@ -69,26 +68,22 @@
 
 package net.canfar.storage.web;
 
-import net.canfar.storage.PathUtils;
-import net.canfar.storage.web.config.VOSpaceServiceConfig;
-import org.opencadc.gms.GroupURI;
-import org.opencadc.vospace.NodeProperty;
-import net.canfar.storage.AbstractUnitTest;
-import net.canfar.storage.web.view.StorageItem;
-import org.opencadc.vospace.DataNode;
-import org.opencadc.vospace.VOS;
-import org.opencadc.vospace.VOSURI;
-
-import org.junit.Test;
-import org.junit.Assert;
-
 import java.net.URI;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-
+import net.canfar.storage.AbstractUnitTest;
+import net.canfar.storage.PathUtils;
+import net.canfar.storage.web.config.VOSpaceServiceConfig;
+import net.canfar.storage.web.view.StorageItem;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opencadc.gms.GroupURI;
+import org.opencadc.vospace.DataNode;
+import org.opencadc.vospace.NodeProperty;
+import org.opencadc.vospace.VOS;
+import org.opencadc.vospace.VOSURI;
 
 public class StorageItemFactoryTest extends AbstractUnitTest<StorageItemFactory> {
     @Test
@@ -109,16 +104,18 @@ public class StorageItemFactoryTest extends AbstractUnitTest<StorageItemFactory>
         testDataNode.bytesUsed = 88000L;
         testDataNode.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_READABLE, Boolean.TRUE.toString()));
 
-        final VOSpaceServiceConfig testServiceConfig =
-                new VOSpaceServiceConfig("vault", URI.create("ivo://example.org/vault"),
-                                         URI.create("vos://example.org~vault"), new VOSpaceServiceConfig.Features());
+        final VOSpaceServiceConfig testServiceConfig = new VOSpaceServiceConfig(
+                "vault",
+                URI.create("ivo://example.org/vault"),
+                URI.create("vos://example.org~vault"),
+                new VOSpaceServiceConfig.Features(),
+                URI.create("https://example.com/groups"));
 
         testSubject = new StorageItemFactory(contextPath, testServiceConfig);
 
         final StorageItem storageItemResult = testSubject.translate(testDataNode);
-        Assert.assertEquals("Wrong target URL.",
-                            "/warehouse/vault/file/myroot/path/file.txt",
-                            storageItemResult.getTargetPath());
+        Assert.assertEquals(
+                "Wrong target URL.", "/warehouse/vault/file/myroot/path/file.txt", storageItemResult.getTargetPath());
 
         final String readGroupNames = "GROUP2 GROUP3";
         Assert.assertEquals("Wrong Read groups.", readGroupNames, storageItemResult.getReadGroupNames());
@@ -127,8 +124,7 @@ public class StorageItemFactoryTest extends AbstractUnitTest<StorageItemFactory>
         Assert.assertEquals("Wrong Write groups.", writeGroupNames, storageItemResult.getWriteGroupNames());
 
         Assert.assertEquals("Wrong size in bytes.", 88000L, storageItemResult.getSizeInBytes());
-        Assert.assertEquals("Wrong size in human readable.", "85.94 KB",
-                            storageItemResult.getSizeHumanReadable());
+        Assert.assertEquals("Wrong size in human readable.", "85.94 KB", storageItemResult.getSizeHumanReadable());
     }
 
     @Test
@@ -149,16 +145,18 @@ public class StorageItemFactoryTest extends AbstractUnitTest<StorageItemFactory>
         testDataNode.bytesUsed = 88000L;
         testDataNode.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_READABLE, Boolean.TRUE.toString()));
 
-        final VOSpaceServiceConfig testServiceConfig =
-                new VOSpaceServiceConfig("vault", URI.create("ivo://example.org/vault"),
-                                         URI.create("vos://example.org~vault"), new VOSpaceServiceConfig.Features());
+        final VOSpaceServiceConfig testServiceConfig = new VOSpaceServiceConfig(
+                "vault",
+                URI.create("ivo://example.org/vault"),
+                URI.create("vos://example.org~vault"),
+                new VOSpaceServiceConfig.Features(),
+                URI.create("https://example.com/groups"));
 
         testSubject = new StorageItemFactory(contextPath, testServiceConfig);
 
         final StorageItem storageItemResult = testSubject.translate(testDataNode);
-        Assert.assertEquals("Wrong target URL.",
-                            "/warehouse/vault/file/myroot/path/file.txt",
-                            storageItemResult.getTargetPath());
+        Assert.assertEquals(
+                "Wrong target URL.", "/warehouse/vault/file/myroot/path/file.txt", storageItemResult.getTargetPath());
 
         final String readGroupNames = "GROUP2 GROUP3";
         Assert.assertEquals("Wrong Read groups.", readGroupNames, storageItemResult.getReadGroupNames());
@@ -167,8 +165,7 @@ public class StorageItemFactoryTest extends AbstractUnitTest<StorageItemFactory>
         Assert.assertEquals("Wrong Write groups.", writeGroupNames, storageItemResult.getWriteGroupNames());
 
         Assert.assertEquals("Wrong size in bytes.", 88000L, storageItemResult.getSizeInBytes());
-        Assert.assertEquals("Wrong size in human readable.", "85.94 KB",
-                            storageItemResult.getSizeHumanReadable());
+        Assert.assertEquals("Wrong size in human readable.", "85.94 KB", storageItemResult.getSizeHumanReadable());
     }
 
     @Test
@@ -182,22 +179,23 @@ public class StorageItemFactoryTest extends AbstractUnitTest<StorageItemFactory>
         testDataNode.bytesUsed = 88000L;
         testDataNode.getProperties().add(new NodeProperty(VOS.PROPERTY_URI_READABLE, Boolean.TRUE.toString()));
 
-        final VOSpaceServiceConfig testServiceConfig =
-                new VOSpaceServiceConfig("vault", URI.create("ivo://example.org/vault"),
-                                         URI.create("vos://example.org~vault"), new VOSpaceServiceConfig.Features());
+        final VOSpaceServiceConfig testServiceConfig = new VOSpaceServiceConfig(
+                "vault",
+                URI.create("ivo://example.org/vault"),
+                URI.create("vos://example.org~vault"),
+                new VOSpaceServiceConfig.Features(),
+                URI.create("https://example.com/groups"));
 
         testSubject = new StorageItemFactory(contextPath, testServiceConfig);
 
         final StorageItem storageItemResult = testSubject.translate(testDataNode);
-        Assert.assertEquals("Wrong target URL.",
-                            "/warehouse/vault/file/myroot/path/file.txt",
-                            storageItemResult.getTargetPath());
+        Assert.assertEquals(
+                "Wrong target URL.", "/warehouse/vault/file/myroot/path/file.txt", storageItemResult.getTargetPath());
 
         Assert.assertEquals("Wrong Read groups.", "", storageItemResult.getReadGroupNames());
         Assert.assertEquals("Wrong Write groups.", "", storageItemResult.getWriteGroupNames());
 
         Assert.assertEquals("Wrong size in bytes.", 88000L, storageItemResult.getSizeInBytes());
-        Assert.assertEquals("Wrong size in human readable.", "85.94 KB",
-                            storageItemResult.getSizeHumanReadable());
+        Assert.assertEquals("Wrong size in human readable.", "85.94 KB", storageItemResult.getSizeHumanReadable());
     }
 }

--- a/src/test/java/net/canfar/storage/web/config/VOSpaceServiceConfigTest.java
+++ b/src/test/java/net/canfar/storage/web/config/VOSpaceServiceConfigTest.java
@@ -67,10 +67,8 @@
  */
 package net.canfar.storage.web.config;
 
-import net.canfar.storage.AbstractUnitTest;
-
 import java.net.URI;
-
+import net.canfar.storage.AbstractUnitTest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -83,8 +81,12 @@ public class VOSpaceServiceConfigTest extends AbstractUnitTest<VOSpaceServiceCon
     @Test
     public void testBadVOspaceServiceConfig() throws Exception {
         try {
-            new VOSpaceServiceConfig("", testVOSpaceServiceURI, testVOSpaceNodeURI,
-                                     new VOSpaceServiceConfig.Features());
+            new VOSpaceServiceConfig(
+                    "",
+                    testVOSpaceServiceURI,
+                    testVOSpaceNodeURI,
+                    new VOSpaceServiceConfig.Features(),
+                    URI.create("https://example.com/groups"));
 
             // Values will be stored as passed in, no need to test quality
             Assert.fail("ctor should have reported error for service name");
@@ -92,10 +94,13 @@ public class VOSpaceServiceConfigTest extends AbstractUnitTest<VOSpaceServiceCon
             // pass
         }
 
-
         try {
-            new VOSpaceServiceConfig(serviceName, null, testVOSpaceNodeURI,
-                                     new VOSpaceServiceConfig.Features());
+            new VOSpaceServiceConfig(
+                    serviceName,
+                    null,
+                    testVOSpaceNodeURI,
+                    new VOSpaceServiceConfig.Features(),
+                    URI.create("https://example.com/groups"));
 
             // Values will be stored as passed in, no need to test quality
             Assert.fail("ctor should have reported error for service resourceID");
@@ -104,8 +109,12 @@ public class VOSpaceServiceConfigTest extends AbstractUnitTest<VOSpaceServiceCon
         }
 
         try {
-            new VOSpaceServiceConfig(serviceName, testVOSpaceServiceURI, null,
-                                     new VOSpaceServiceConfig.Features());
+            new VOSpaceServiceConfig(
+                    serviceName,
+                    testVOSpaceServiceURI,
+                    null,
+                    new VOSpaceServiceConfig.Features(),
+                    URI.create("https://example.com/groups"));
 
             // Values will be stored as passed in, no need to test quality
             Assert.fail("ctor should have reported error for node resourceID");
@@ -113,5 +122,4 @@ public class VOSpaceServiceConfigTest extends AbstractUnitTest<VOSpaceServiceCon
             // pass
         }
     }
-
 }

--- a/src/test/java/net/canfar/storage/web/resources/FolderItemServerResourceTest.java
+++ b/src/test/java/net/canfar/storage/web/resources/FolderItemServerResourceTest.java
@@ -68,42 +68,35 @@
 
 package net.canfar.storage.web.resources;
 
+import static org.junit.Assert.*;
 
 import ca.nrc.cadc.reg.client.RegistryClient;
-import net.canfar.storage.FileSizeRepresentation;
 import ca.nrc.cadc.uws.ErrorSummary;
 import ca.nrc.cadc.uws.ErrorType;
 import ca.nrc.cadc.uws.ExecutionPhase;
-import net.canfar.storage.web.StorageItemFactory;
-import net.canfar.storage.web.config.VOSpaceServiceConfig;
-import org.opencadc.vospace.*;
-
-import org.opencadc.vospace.client.ClientTransfer;
-import org.json.JSONObject;
-import org.mockito.Mockito;
-import org.opencadc.vospace.transfer.Transfer;
-import org.restlet.Context;
-import org.restlet.Response;
-
 import java.io.StringWriter;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-
+import javax.security.auth.Subject;
+import javax.servlet.ServletContext;
+import net.canfar.storage.FileSizeRepresentation;
+import net.canfar.storage.web.StorageItemFactory;
+import net.canfar.storage.web.config.VOSpaceServiceConfig;
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opencadc.vospace.*;
+import org.opencadc.vospace.client.ClientTransfer;
+import org.opencadc.vospace.transfer.Transfer;
+import org.restlet.Context;
+import org.restlet.Response;
 import org.restlet.data.Status;
 import org.restlet.ext.json.JsonRepresentation;
 import org.restlet.representation.Representation;
-
-import javax.security.auth.Subject;
-import javax.servlet.ServletContext;
-
-import org.junit.Assert;
-import org.junit.Test;
 import org.restlet.resource.ResourceException;
-
-import static org.junit.Assert.*;
-
 
 public class FolderItemServerResourceTest extends AbstractServerResourceTest<FolderItemServerResource> {
     @Test
@@ -111,60 +104,67 @@ public class FolderItemServerResourceTest extends AbstractServerResourceTest<Fol
         final VOSURI folderURI = new VOSURI(URI.create(VOSPACE_NODE_URI_PREFIX + "/my/node"));
         final ContainerNode containerNode = new ContainerNode("node");
 
-        final VOSpaceServiceConfig testServiceConfig =
-                new VOSpaceServiceConfig("myvospace", URI.create("ivo://example.org/myvospace"),
-                                         URI.create("vos://example.org~myvospace"), new VOSpaceServiceConfig.Features());
+        final VOSpaceServiceConfig testServiceConfig = new VOSpaceServiceConfig(
+                "myvospace",
+                URI.create("ivo://example.org/myvospace"),
+                URI.create("vos://example.org~myvospace"),
+                new VOSpaceServiceConfig.Features(),
+                URI.create("https://example.com/groups"));
 
         final Map<String, Object> requestAttributes = new HashMap<>();
         requestAttributes.put("path", folderURI.getPath());
 
         Mockito.when(mockServletContext.getContextPath()).thenReturn("/teststorage");
         Mockito.when(mockVOSpaceClient.createNode(folderURI, containerNode, false))
-               .thenReturn(containerNode);
+                .thenReturn(containerNode);
 
-        testSubject = new FolderItemServerResource(null, null,
-                                                   new StorageItemFactory("/servletpath", testServiceConfig),
-                                                   mockVOSpaceClient, testServiceConfig) {
-            @Override
-            VOSURI getCurrentItemURI() {
-                return folderURI;
-            }
+        testSubject =
+                new FolderItemServerResource(
+                        null,
+                        null,
+                        new StorageItemFactory("/servletpath", testServiceConfig),
+                        mockVOSpaceClient,
+                        testServiceConfig) {
+                    @Override
+                    VOSURI getCurrentItemURI() {
+                        return folderURI;
+                    }
 
-            @Override
-            Subject getVOSpaceCallingSubject() {
-                return new Subject();
-            }
+                    @Override
+                    Subject getVOSpaceCallingSubject() {
+                        return new Subject();
+                    }
 
-            @Override
-            public Map<String, Object> getRequestAttributes() {
-                return requestAttributes;
-            }
+                    @Override
+                    public Map<String, Object> getRequestAttributes() {
+                        return requestAttributes;
+                    }
 
-            /**
-             * Returns the current context.
-             *
-             * @return The current context.
-             */
-            @Override
-            public Context getContext() {
-                return mockContext;
-            }
+                    /**
+                     * Returns the current context.
+                     *
+                     * @return The current context.
+                     */
+                    @Override
+                    public Context getContext() {
+                        return mockContext;
+                    }
 
-            /**
-             * Returns the handled response.
-             *
-             * @return The handled response.
-             */
-            @Override
-            public Response getResponse() {
-                return mockResponse;
-            }
+                    /**
+                     * Returns the handled response.
+                     *
+                     * @return The handled response.
+                     */
+                    @Override
+                    public Response getResponse() {
+                        return mockResponse;
+                    }
 
-            @Override
-            RegistryClient getRegistryClient() {
-                return mockRegistryClient;
-            }
-        };
+                    @Override
+                    RegistryClient getRegistryClient() {
+                        return mockRegistryClient;
+                    }
+                };
 
         Mockito.doNothing().when(mockResponse).setStatus(Status.SUCCESS_CREATED);
 
@@ -193,9 +193,12 @@ public class FolderItemServerResourceTest extends AbstractServerResourceTest<Fol
         final String expectedQuota = FileSizeRepresentation.getSizeHumanReadable(quota);
         final VOSURI folderURI = new VOSURI(URI.create(VOSPACE_NODE_URI_PREFIX + "/my/node"));
 
-        final VOSpaceServiceConfig testServiceConfig =
-                new VOSpaceServiceConfig("vault", URI.create("ivo://example.org/vault"),
-                                         URI.create("vos://example.org~vault"), new VOSpaceServiceConfig.Features());
+        final VOSpaceServiceConfig testServiceConfig = new VOSpaceServiceConfig(
+                "vault",
+                URI.create("ivo://example.org/vault"),
+                URI.create("vos://example.org~vault"),
+                new VOSpaceServiceConfig.Features(),
+                URI.create("https://example.com/groups"));
         final NodeProperty prop = new NodeProperty(VOS.PROPERTY_URI_QUOTA, Long.toString(quota));
 
         final ContainerNode containerNode = new ContainerNode("node");
@@ -205,40 +208,44 @@ public class FolderItemServerResourceTest extends AbstractServerResourceTest<Fol
         final Map<String, Object> requestAttributes = new HashMap<>();
         requestAttributes.put("path", folderURI.getPath());
 
-        testSubject = new FolderItemServerResource(null, null,
-                                                   new StorageItemFactory("/servletpath", testServiceConfig),
-                                                   mockVOSpaceClient, testServiceConfig) {
-            @Override
-            VOSURI getCurrentItemURI() {
-                return folderURI;
-            }
+        testSubject =
+                new FolderItemServerResource(
+                        null,
+                        null,
+                        new StorageItemFactory("/servletpath", testServiceConfig),
+                        mockVOSpaceClient,
+                        testServiceConfig) {
+                    @Override
+                    VOSURI getCurrentItemURI() {
+                        return folderURI;
+                    }
 
-            @Override
-            public Map<String, Object> getRequestAttributes() {
-                return requestAttributes;
-            }
+                    @Override
+                    public Map<String, Object> getRequestAttributes() {
+                        return requestAttributes;
+                    }
 
-            /**
-             * Returns the handled response.
-             *
-             * @return The handled response.
-             */
-            @Override
-            public Response getResponse() {
-                return mockResponse;
-            }
+                    /**
+                     * Returns the handled response.
+                     *
+                     * @return The handled response.
+                     */
+                    @Override
+                    public Response getResponse() {
+                        return mockResponse;
+                    }
 
-            @Override
-            ServletContext getServletContext() {
-                return mockServletContext;
-            }
+                    @Override
+                    ServletContext getServletContext() {
+                        return mockServletContext;
+                    }
 
-            @SuppressWarnings("unchecked")
-            @Override
-            <T extends Node> T getNode(final Path nodePath, final VOS.Detail detail) throws ResourceException {
-                return (T) containerNode;
-            }
-        };
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    <T extends Node> T getNode(final Path nodePath, final VOS.Detail detail) throws ResourceException {
+                        return (T) containerNode;
+                    }
+                };
 
         Representation jsonRep = testSubject.retrieveQuota();
 
@@ -262,7 +269,6 @@ public class FolderItemServerResourceTest extends AbstractServerResourceTest<Fol
                     break;
             }
         }
-
     }
 
     private String extract(final String text) {
@@ -270,7 +276,6 @@ public class FolderItemServerResourceTest extends AbstractServerResourceTest<Fol
         int endIndex = text.lastIndexOf('"');
         return text.substring(beginIndex + 1, endIndex);
     }
-
 
     @Test
     public void moveItemsToFolder() throws Exception {
@@ -289,9 +294,12 @@ public class FolderItemServerResourceTest extends AbstractServerResourceTest<Fol
         mockClientTransfer.setMonitor(true);
         mockClientTransfer.runTransfer();
 
-        final VOSpaceServiceConfig testServiceConfig =
-                new VOSpaceServiceConfig("myvospace", URI.create("ivo://example.org/myvospace"),
-                                         URI.create("vos://example.org~myvospace"), new VOSpaceServiceConfig.Features());
+        final VOSpaceServiceConfig testServiceConfig = new VOSpaceServiceConfig(
+                "myvospace",
+                URI.create("ivo://example.org/myvospace"),
+                URI.create("vos://example.org~myvospace"),
+                new VOSpaceServiceConfig.Features(),
+                URI.create("https://example.com/groups"));
 
         final Map<String, Object> requestAttributes = new HashMap<>();
         requestAttributes.put("path", destination.getPath());
@@ -308,60 +316,62 @@ public class FolderItemServerResourceTest extends AbstractServerResourceTest<Fol
         Mockito.when(mockVOSpaceClient.createTransfer(mockTransfer)).thenReturn(mockClientTransfer);
         Mockito.when(mockServletContext.getContextPath()).thenReturn("/teststorage");
 
+        testSubject =
+                new FolderItemServerResource(
+                        null,
+                        null,
+                        new StorageItemFactory("/servletpath", testServiceConfig),
+                        mockVOSpaceClient,
+                        testServiceConfig) {
+                    @Override
+                    RegistryClient getRegistryClient() {
+                        return mockRegistryClient;
+                    }
 
-        testSubject = new FolderItemServerResource(null, null,
-                                                   new StorageItemFactory("/servletpath", testServiceConfig),
-                                                   mockVOSpaceClient, testServiceConfig) {
-            @Override
-            RegistryClient getRegistryClient() {
-                return mockRegistryClient;
-            }
+                    @Override
+                    public Map<String, Object> getRequestAttributes() {
+                        return requestAttributes;
+                    }
 
-            @Override
-            public Map<String, Object> getRequestAttributes() {
-                return requestAttributes;
-            }
+                    /**
+                     * Returns the current context.
+                     *
+                     * @return The current context.
+                     */
+                    @Override
+                    public Context getContext() {
+                        return mockContext;
+                    }
 
-            /**
-             * Returns the current context.
-             *
-             * @return The current context.
-             */
-            @Override
-            public Context getContext() {
-                return mockContext;
-            }
+                    @Override
+                    Subject getVOSpaceCallingSubject() {
+                        return new Subject();
+                    }
 
-            @Override
-            Subject getVOSpaceCallingSubject() {
-                return new Subject();
-            }
+                    @Override
+                    public Response getResponse() {
+                        return mockResponse;
+                    }
 
-            @Override
-            public Response getResponse() {
-                return mockResponse;
-            }
+                    @Override
+                    VOSURI getCurrentItemURI() {
+                        return destination;
+                    }
 
-            @Override
-            VOSURI getCurrentItemURI() {
-                return destination;
-            }
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    <T extends Node> T getNode(Path nodePath, VOS.Detail detail) throws ResourceException {
+                        return (T) mockDestinationNode;
+                    }
 
-            @SuppressWarnings("unchecked")
-            @Override
-            <T extends Node> T getNode(Path nodePath, VOS.Detail detail) throws ResourceException {
-                return (T) mockDestinationNode;
-            }
+                    @Override
+                    Transfer getTransfer(VOSURI source, VOSURI destination) {
+                        return mockTransfer;
+                    }
+                };
 
-            @Override
-            Transfer getTransfer(VOSURI source, VOSURI destination) {
-                return mockTransfer;
-            }
-        };
-
-
-        final JSONObject sourceJSON = new JSONObject("{\"destNode\":\"" + destNodeName + "\","
-                                                     + "\"srcNodes\":\"" + srcNodeName + "\"}");
+        final JSONObject sourceJSON =
+                new JSONObject("{\"destNode\":\"" + destNodeName + "\"," + "\"srcNodes\":\"" + srcNodeName + "\"}");
 
         final JsonRepresentation payload = new JsonRepresentation(sourceJSON);
 

--- a/src/test/java/net/canfar/storage/web/resources/LinkItemServerResourceTest.java
+++ b/src/test/java/net/canfar/storage/web/resources/LinkItemServerResourceTest.java
@@ -69,27 +69,25 @@
 package net.canfar.storage.web.resources;
 
 import ca.nrc.cadc.reg.client.RegistryClient;
-import net.canfar.storage.web.StorageItemFactory;
-import net.canfar.storage.web.config.VOSpaceServiceConfig;
-import org.opencadc.vospace.ContainerNode;
-import org.opencadc.vospace.LinkNode;
-import org.opencadc.vospace.VOSURI;
-import org.json.JSONObject;
-import org.junit.Test;
-import org.mockito.Mockito;
-import org.restlet.Context;
-import org.restlet.Request;
-import org.restlet.Response;
-import org.restlet.data.Status;
-import org.restlet.ext.json.JsonRepresentation;
-
-import javax.security.auth.Subject;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-
+import javax.security.auth.Subject;
+import net.canfar.storage.web.StorageItemFactory;
+import net.canfar.storage.web.config.VOSpaceServiceConfig;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.opencadc.vospace.ContainerNode;
+import org.opencadc.vospace.LinkNode;
+import org.opencadc.vospace.VOSURI;
+import org.restlet.Context;
+import org.restlet.Request;
+import org.restlet.Response;
+import org.restlet.data.Status;
+import org.restlet.ext.json.JsonRepresentation;
 
 public class LinkItemServerResourceTest extends AbstractServerResourceTest<LinkItemServerResource> {
     @Test
@@ -98,15 +96,18 @@ public class LinkItemServerResourceTest extends AbstractServerResourceTest<LinkI
         final VOSURI expectedURI = new VOSURI(URI.create(VOSPACE_NODE_URI_PREFIX + "/curr/dir/MY_LINK"));
         final LinkNode linkNode = new LinkNode("MY_LINK", target);
 
-        final VOSpaceServiceConfig testServiceConfig =
-                new VOSpaceServiceConfig("vault", URI.create("ivo://ca.nrc.cadc/vault"),
-                                         URI.create(VOSPACE_NODE_URI_PREFIX), new VOSpaceServiceConfig.Features());
+        final VOSpaceServiceConfig testServiceConfig = new VOSpaceServiceConfig(
+                "vault",
+                URI.create("ivo://ca.nrc.cadc/vault"),
+                URI.create(VOSPACE_NODE_URI_PREFIX),
+                new VOSpaceServiceConfig.Features(),
+                URI.create("https://example.com/groups"));
 
         Mockito.when(mockServletContext.getContextPath()).thenReturn("/to");
         Mockito.when(mockVOSpaceClient.createNode(expectedURI, linkNode, false)).thenReturn(linkNode);
 
-        final JSONObject sourceJSON = new JSONObject("{\"link_name\":\"MY_LINK\","
-                                                     + "\"link_url\":\"http://gohere.com/to/see\"}");
+        final JSONObject sourceJSON =
+                new JSONObject("{\"link_name\":\"MY_LINK\"," + "\"link_url\":\"http://gohere.com/to/see\"}");
 
         final JsonRepresentation payload = new JsonRepresentation(sourceJSON);
 
@@ -117,50 +118,54 @@ public class LinkItemServerResourceTest extends AbstractServerResourceTest<LinkI
         Mockito.doNothing().when(mockResponse).setStatus(Status.SUCCESS_CREATED);
         Mockito.when(mockContext.getAttributes()).thenReturn(new ConcurrentHashMap<>());
 
-        testSubject = new LinkItemServerResource(null, null,
-                                                 new StorageItemFactory("/servletpath", testServiceConfig),
-                                                 mockVOSpaceClient, testServiceConfig) {
-            @Override
-            RegistryClient getRegistryClient() {
-                return mockRegistryClient;
-            }
+        testSubject =
+                new LinkItemServerResource(
+                        null,
+                        null,
+                        new StorageItemFactory("/servletpath", testServiceConfig),
+                        mockVOSpaceClient,
+                        testServiceConfig) {
+                    @Override
+                    RegistryClient getRegistryClient() {
+                        return mockRegistryClient;
+                    }
 
-            @Override
-            Subject getVOSpaceCallingSubject() {
-                return new Subject();
-            }
+                    @Override
+                    Subject getVOSpaceCallingSubject() {
+                        return new Subject();
+                    }
 
-            /**
-             * Returns the current context.
-             *
-             * @return The current context.
-             */
-            @Override
-            public Context getContext() {
-                return mockContext;
-            }
+                    /**
+                     * Returns the current context.
+                     *
+                     * @return The current context.
+                     */
+                    @Override
+                    public Context getContext() {
+                        return mockContext;
+                    }
 
-            /**
-             * Returns the request attributes.
-             *
-             * @return The request attributes.
-             * @see Request#getAttributes()
-             */
-            @Override
-            public Map<String, Object> getRequestAttributes() {
-                return attributes;
-            }
+                    /**
+                     * Returns the request attributes.
+                     *
+                     * @return The request attributes.
+                     * @see Request#getAttributes()
+                     */
+                    @Override
+                    public Map<String, Object> getRequestAttributes() {
+                        return attributes;
+                    }
 
-            /**
-             * Returns the handled response.
-             *
-             * @return The handled response.
-             */
-            @Override
-            public Response getResponse() {
-                return mockResponse;
-            }
-        };
+                    /**
+                     * Returns the handled response.
+                     *
+                     * @return The handled response.
+                     */
+                    @Override
+                    public Response getResponse() {
+                        return mockResponse;
+                    }
+                };
 
         testSubject.create(payload);
 
@@ -174,9 +179,12 @@ public class LinkItemServerResourceTest extends AbstractServerResourceTest<LinkI
         final URI target = URI.create("vos://cadc.nrc.ca!linktest/other/dir/my/dir");
         final LinkNode linkNode = new LinkNode("MY_LINK", target);
         final ContainerNode targetContainerNode = new ContainerNode("dir");
-        final VOSpaceServiceConfig testServiceConfig =
-                new VOSpaceServiceConfig("linktest", URI.create("ivo://example.org/linktest"),
-                                         URI.create("vos://example.org~linktest"), new VOSpaceServiceConfig.Features());
+        final VOSpaceServiceConfig testServiceConfig = new VOSpaceServiceConfig(
+                "linktest",
+                URI.create("ivo://example.org/linktest"),
+                URI.create("vos://example.org~linktest"),
+                new VOSpaceServiceConfig.Features(),
+                URI.create("https://example.com/groups"));
 
         final Map<String, Object> attributes = new HashMap<>();
         attributes.put("path", "/curr/dir/MY_LINK");
@@ -185,59 +193,62 @@ public class LinkItemServerResourceTest extends AbstractServerResourceTest<LinkI
         Mockito.when(mockContext.getAttributes()).thenReturn(mockAttributeMap);
 
         Mockito.when(mockVOSpaceClient.getNode("/other/dir/my/dir", getNodeRequestQuery))
-               .thenReturn(targetContainerNode);
-        Mockito.when(mockVOSpaceClient.getNode("/curr/dir/MY_LINK", getNodeRequestQuery)).thenReturn(linkNode);
+                .thenReturn(targetContainerNode);
+        Mockito.when(mockVOSpaceClient.getNode("/curr/dir/MY_LINK", getNodeRequestQuery))
+                .thenReturn(linkNode);
 
-        testSubject = new LinkItemServerResource(null, null,
-                                                 new StorageItemFactory("/servletpath", testServiceConfig),
-                                                 mockVOSpaceClient, testServiceConfig) {
-            @Override
-            RegistryClient getRegistryClient() {
-                return mockRegistryClient;
-            }
+        testSubject =
+                new LinkItemServerResource(
+                        null,
+                        null,
+                        new StorageItemFactory("/servletpath", testServiceConfig),
+                        mockVOSpaceClient,
+                        testServiceConfig) {
+                    @Override
+                    RegistryClient getRegistryClient() {
+                        return mockRegistryClient;
+                    }
 
-            @Override
-            Subject getVOSpaceCallingSubject() {
-                return new Subject();
-            }
+                    @Override
+                    Subject getVOSpaceCallingSubject() {
+                        return new Subject();
+                    }
 
-            /**
-             * Returns the current context.
-             *
-             * @return The current context.
-             */
-            @Override
-            public Context getContext() {
-                return mockContext;
-            }
+                    /**
+                     * Returns the current context.
+                     *
+                     * @return The current context.
+                     */
+                    @Override
+                    public Context getContext() {
+                        return mockContext;
+                    }
 
-            /**
-             * Returns the request attributes.
-             *
-             * @return The request attributes.
-             * @see Request#getAttributes()
-             */
-            @Override
-            public Map<String, Object> getRequestAttributes() {
-                return attributes;
-            }
+                    /**
+                     * Returns the request attributes.
+                     *
+                     * @return The request attributes.
+                     * @see Request#getAttributes()
+                     */
+                    @Override
+                    public Map<String, Object> getRequestAttributes() {
+                        return attributes;
+                    }
 
-            /**
-             * Returns the handled response.
-             *
-             * @return The handled response.
-             */
-            @Override
-            public Response getResponse() {
-                return mockResponse;
-            }
-        };
+                    /**
+                     * Returns the handled response.
+                     *
+                     * @return The handled response.
+                     */
+                    @Override
+                    public Response getResponse() {
+                        return mockResponse;
+                    }
+                };
 
         testSubject.resolve();
 
-        Mockito.verify(mockVOSpaceClient, Mockito.times(1)).getNode("/curr/dir/MY_LINK",
-                                                                    getNodeRequestQuery);
-        Mockito.verify(mockVOSpaceClient, Mockito.times(1)).getNode("/other/dir/my/dir",
-                                                                    getNodeRequestQuery);
+        Mockito.verify(mockVOSpaceClient, Mockito.times(1)).getNode("/curr/dir/MY_LINK", getNodeRequestQuery);
+        Mockito.verify(mockVOSpaceClient, Mockito.times(1)).getNode("/other/dir/my/dir", getNodeRequestQuery);
     }
 }

--- a/src/test/java/net/canfar/storage/web/resources/MainPageServerResourceTest.java
+++ b/src/test/java/net/canfar/storage/web/resources/MainPageServerResourceTest.java
@@ -68,34 +68,29 @@
 
 package net.canfar.storage.web.resources;
 
-
-import net.canfar.storage.web.StorageItemFactory;
-import net.canfar.storage.web.config.VOSpaceServiceConfig;
-import net.canfar.storage.web.config.VOSpaceServiceConfigManager;
-import org.opencadc.vospace.*;
-import net.canfar.storage.web.config.StorageConfiguration;
-import net.canfar.storage.web.view.FolderItem;
-import net.canfar.storage.web.view.FreeMarkerConfiguration;
-import org.mockito.Mockito;
-import org.opencadc.token.Client;
-import org.restlet.Context;
-import org.restlet.ext.freemarker.TemplateRepresentation;
-import org.restlet.representation.Representation;
-
-import javax.security.auth.Subject;
-import javax.servlet.ServletContext;
+import static org.junit.Assert.*;
 
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
+import javax.security.auth.Subject;
+import javax.servlet.ServletContext;
+import net.canfar.storage.web.StorageItemFactory;
+import net.canfar.storage.web.config.StorageConfiguration;
+import net.canfar.storage.web.config.VOSpaceServiceConfig;
+import net.canfar.storage.web.config.VOSpaceServiceConfigManager;
+import net.canfar.storage.web.view.FolderItem;
+import net.canfar.storage.web.view.FreeMarkerConfiguration;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.opencadc.token.Client;
+import org.opencadc.vospace.*;
+import org.restlet.Context;
+import org.restlet.ext.freemarker.TemplateRepresentation;
+import org.restlet.representation.Representation;
 import org.restlet.resource.ResourceException;
-
-import static org.junit.Assert.*;
-
 
 public class MainPageServerResourceTest extends AbstractServerResourceTest<MainPageServerResource> {
     @Test
@@ -105,12 +100,14 @@ public class MainPageServerResourceTest extends AbstractServerResourceTest<MainP
         final List<String> initialRowData = new ArrayList<>();
         final ContainerNode containerNode = new ContainerNode("node");
 
-        final VOSpaceServiceConfig testServiceConfig =
-                new VOSpaceServiceConfig("vos", URI.create("ivo://example.org/vos"),
-                                         URI.create("vos://example.org~vos"), new VOSpaceServiceConfig.Features());
+        final VOSpaceServiceConfig testServiceConfig = new VOSpaceServiceConfig(
+                "vos",
+                URI.create("ivo://example.org/vos"),
+                URI.create("vos://example.org~vos"),
+                new VOSpaceServiceConfig.Features(),
+                URI.create("https://example.com/groups"));
 
-        final StorageItemFactory testStorageItemFactory = new StorageItemFactory("/mystore",
-                                                                                 testServiceConfig);
+        final StorageItemFactory testStorageItemFactory = new StorageItemFactory("/mystore", testServiceConfig);
 
         initialRowData.add("child1");
         initialRowData.add("child2");
@@ -129,55 +126,61 @@ public class MainPageServerResourceTest extends AbstractServerResourceTest<MainP
         Mockito.when(mockVOSpaceServiceConfigManager.getServiceList()).thenReturn(vospaceServiceList);
 
         Mockito.when(mockStorageConfiguration.getThemeName()).thenReturn("vos");
-        Mockito.when(mockFreeMarkerConfiguration.getTemplate("themes/vos/index.ftl")).thenReturn(null);
+        Mockito.when(mockFreeMarkerConfiguration.getTemplate("themes/vos/index.ftl"))
+                .thenReturn(null);
 
-        testSubject = new MainPageServerResource(mockStorageConfiguration, mockVOSpaceServiceConfigManager,
-                                                 testStorageItemFactory, mockVOSpaceClient, testServiceConfig) {
-            @Override
-            FreeMarkerConfiguration getFreeMarkerConfiguration() {
-                return mockFreeMarkerConfiguration;
-            }
+        testSubject =
+                new MainPageServerResource(
+                        mockStorageConfiguration,
+                        mockVOSpaceServiceConfigManager,
+                        testStorageItemFactory,
+                        mockVOSpaceClient,
+                        testServiceConfig) {
+                    @Override
+                    FreeMarkerConfiguration getFreeMarkerConfiguration() {
+                        return mockFreeMarkerConfiguration;
+                    }
 
-            @Override
-            Subject getVOSpaceCallingSubject() {
-                return new Subject();
-            }
+                    @Override
+                    Subject getVOSpaceCallingSubject() {
+                        return new Subject();
+                    }
 
-            @Override
-            protected Client getOIDCClient() {
-                return mockOIDCConfiguration;
-            }
+                    @Override
+                    protected Client getOIDCClient() {
+                        return mockOIDCConfiguration;
+                    }
 
-            @Override
-            protected String getDisplayName() {
-                return "testuser";
-            }
+                    @Override
+                    protected String getDisplayName() {
+                        return "testuser";
+                    }
 
-            @Override
-            ServletContext getServletContext() {
-                return mockServletContext;
-            }
+                    @Override
+                    ServletContext getServletContext() {
+                        return mockServletContext;
+                    }
 
-            @Override
-            public Context getContext() {
-                return mockContext;
-            }
+                    @Override
+                    public Context getContext() {
+                        return mockContext;
+                    }
 
-            @Override
-            public String getCurrentVOSpaceService() {
-                return "vos";
-            }
+                    @Override
+                    public String getCurrentVOSpaceService() {
+                        return "vos";
+                    }
 
-            @SuppressWarnings("unchecked")
-            @Override
-            <T extends Node> T getNode(final Path nodePath, final VOS.Detail detail) throws ResourceException {
-                return (T) containerNode;
-            }
-        };
+                    @SuppressWarnings("unchecked")
+                    @Override
+                    <T extends Node> T getNode(final Path nodePath, final VOS.Detail detail) throws ResourceException {
+                        return (T) containerNode;
+                    }
+                };
 
         Mockito.when(mockFolderItem.isWritable()).thenReturn(true);
-        final Representation representation = testSubject.representFolderItem(mockFolderItem,
-                                                                              initialRowData.iterator(), null);
+        final Representation representation =
+                testSubject.representFolderItem(mockFolderItem, initialRowData.iterator(), null);
         final TemplateRepresentation templateRepresentation = (TemplateRepresentation) representation;
         final Map<String, Object> dataModel = (Map<String, Object>) templateRepresentation.getDataModel();
 
@@ -187,7 +190,6 @@ public class MainPageServerResourceTest extends AbstractServerResourceTest<MainP
 
         Mockito.verify(mockVOSpaceServiceConfigManager, Mockito.times(1)).getServiceList();
         Mockito.verify(mockStorageConfiguration, Mockito.times(1)).getThemeName();
-        Mockito.verify(mockFreeMarkerConfiguration, Mockito.times(1))
-               .getTemplate("themes/vos/index.ftl");
+        Mockito.verify(mockFreeMarkerConfiguration, Mockito.times(1)).getTemplate("themes/vos/index.ftl");
     }
 }


### PR DESCRIPTION
# Description
The `Manage Groups` link is hard coded to the CANFAR version.  Make it configurable for the SRC Network.

# Changes
Add new property for each backend to configure the link.  